### PR TITLE
Hit-for-miss (sw-dynamic-cache-bypass) + observability header

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -24,6 +24,12 @@ pub struct StoredMeta {
     #[serde(default)]
     pub url: String,
 
+    /// Varnish-style hit-for-miss marker: entry exists but should never be served.
+    ///
+    /// If true, lookups treat this as a cache bypass for a short TTL.
+    #[serde(default)]
+    pub hit_for_miss: bool,
+
     pub stored_at_ms: u64,
     pub ttl_ms: u64,
     pub grace_ms: u64,


### PR DESCRIPTION
Implements Varnish-style hit-for-miss and basic observability.

- Adds `hit_for_miss` flag to stored meta
- When origin responds with `sw-dynamic-cache-bypass: 1`, store a 1s hit-for-miss marker and return BYPASS
- Lookup returns one of: HIT / STALE / HIT_FOR_MISS
- Adds `x-codycache` response header: HIT, MISS, REFRESH, STALE, BYPASS, BAN

Updates issue #1 checklist.