### PR TITLE
Stream non-cacheable/bypass responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.7" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "gzip", "brotli", "deflate"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "gzip", "brotli", "deflate", "stream"] }
 http = "1"
 bytes = "1"
 serde = { version = "1", features = ["derive"] }
@@ -16,6 +16,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 thiserror = "1"
 parking_lot = "0.12"
 url = "2"
+
+futures-util = "0.3"
 
 # IP/CIDR parsing
 ipnet = "2"


### PR DESCRIPTION
Implements streaming proxying for responses that are not stored in cache.

- Adds reqwest `stream` feature + futures-util
- In cache miss path:
  - Cacheable responses still buffer (needed to store)
  - Non-cacheable and sw-dynamic-cache-bypass responses stream to client (no full-body buffering)

This reduces memory usage and improves latency for large uncacheable responses.

Related to issue #1 (Streaming proxying).